### PR TITLE
Cart-pole tuning

### DIFF
--- a/examples/cart_pole_ppo.py
+++ b/examples/cart_pole_ppo.py
@@ -22,7 +22,7 @@ def train():
     """Train the swingup policy and save it to a file."""
     # Create policy and value functions
     network_wrapper = BraxPPONetworksWrapper(
-        policy_network=MLP(layer_sizes=(8, 8, 2)),
+        policy_network=MLP(layer_sizes=(32, 32, 2)),
         value_network=MLP(layer_sizes=(64, 64, 1)),
         action_distribution=NormalTanhDistribution,
     )
@@ -35,7 +35,7 @@ def train():
         tensorboard_logdir="/tmp/rl_playground/cart_pole_ppo",
         num_timesteps=60_000_000,
         num_evals=10,
-        reward_scaling=0.1,
+        reward_scaling=0.01,
         episode_length=100,
         normalize_observations=True,
         unroll_length=10,
@@ -44,7 +44,7 @@ def train():
         discounting=0.97,
         learning_rate=1e-3,
         clipping_epsilon=0.2,
-        entropy_cost=1e-3,
+        entropy_cost=1e-2,
         num_envs=2048,
         batch_size=1024,
         seed=0,

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -8,9 +8,9 @@
     <size nstack="3000" />
     <worldbody>
         <camera name="camera" pos="0.0 3.0 0.8" xyaxes="-1.0 0.0 0.0 0.0 0.0 1.0" mode="fixed"/>
-        <geom name="rail" pos="0 0 0.8" quat="0.707 0 0.707 0" size="0.02 1" type="capsule" />
+        <geom name="rail" pos="0 0 0.8" quat="0.707 0 0.707 0" size="0.02 2" type="capsule" />
         <body name="cart" pos="0 0 0.8">
-            <joint axis="1 0 0" limited="true" name="slider" pos="0 0 0.1" range="-1 1" type="slide" />
+            <joint axis="1 0 0" limited="true" name="slider" pos="0 0 0.1" range="-2 2" type="slide" />
             <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" />
             <body name="pole" pos="0 0 0">
                 <joint axis="0 1 0" name="hinge" pos="0 0 0" range="-inf inf" type="hinge" />

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -2,8 +2,8 @@
     <option solver="Newton" timestep="0.02" iterations="1" ls_iterations="4" />
     <compiler inertiafromgeom="true" />
     <default>
-        <joint armature="0" damping="1" limited="true" />
-        <geom contype="0" friction="1 0.1 0.1" />
+        <joint armature="0" damping="1e-5" limited="true" />
+        <geom contype="0" />
     </default>
     <size nstack="3000" />
     <worldbody>
@@ -14,7 +14,7 @@
             <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" mass="1.0" />
             <body name="pole" pos="0 0 0">
                 <joint axis="0 1 0" name="hinge" pos="0 0 0" range="-inf inf" type="hinge" />
-                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.035 0.3" type="capsule" mass="0.1"/>
+                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.05 0.3" type="capsule" mass="0.1"/>
             </body>
         </body>
     </worldbody>

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -7,14 +7,14 @@
     </default>
     <size nstack="3000" />
     <worldbody>
-        <camera name="camera" pos="0.0 3.0 0.8" xyaxes="-1.0 0.0 0.0 0.0 0.0 1.0" mode="fixed"/>
+        <camera name="camera" pos="0.0 6.0 0.8" xyaxes="-1.0 0.0 0.0 0.0 0.0 1.0" mode="fixed"/>
         <geom name="rail" pos="0 0 0.8" quat="0.707 0 0.707 0" size="0.02 2" type="capsule" />
         <body name="cart" pos="0 0 0.8">
             <joint axis="1 0 0" limited="true" name="slider" pos="0 0 0.1" range="-2 2" type="slide" />
             <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" />
             <body name="pole" pos="0 0 0">
                 <joint axis="0 1 0" name="hinge" pos="0 0 0" range="-inf inf" type="hinge" />
-                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.049 0.3" type="capsule" />
+                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.035 0.3" type="capsule" />
             </body>
         </body>
     </worldbody>

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -19,6 +19,6 @@
         </body>
     </worldbody>
     <actuator>
-        <motor ctrllimited="true" ctrlrange="-1 1" gear="10" joint="slider" name="slide" />
+        <motor ctrllimited="true" ctrlrange="-1 1" gear="5" joint="slider" name="slide" />
     </actuator>
 </mujoco>

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -11,14 +11,14 @@
         <geom name="rail" pos="0 0 0.8" quat="0.707 0 0.707 0" size="0.02 2" type="capsule" />
         <body name="cart" pos="0 0 0.8">
             <joint axis="1 0 0" limited="true" name="slider" pos="0 0 0.1" range="-2 2" type="slide" />
-            <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" />
+            <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" mass="1.0" />
             <body name="pole" pos="0 0 0">
                 <joint axis="0 1 0" name="hinge" pos="0 0 0" range="-inf inf" type="hinge" />
-                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.035 0.3" type="capsule" />
+                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.035 0.3" type="capsule" mass="0.1"/>
             </body>
         </body>
     </worldbody>
     <actuator>
-        <motor ctrllimited="true" ctrlrange="-1 1" gear="100" joint="slider" name="slide" />
+        <motor ctrllimited="true" ctrlrange="-1 1" gear="10" joint="slider" name="slide" />
     </actuator>
 </mujoco>

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -14,7 +14,7 @@
             <geom name="cart" pos="0 0 0" quat="0.707 0 0.707 0" size="0.1 0.1" type="capsule" />
             <body name="pole" pos="0 0 0">
                 <joint axis="0 1 0" name="hinge" pos="0 0 0" range="-inf inf" type="hinge" />
-                <geom fromto="0 0 0 0.001 0 0.6" name="cpole" size="0.049 0.3" type="capsule" />
+                <geom fromto="0 0 0 0.001 0 0.7" name="cpole" size="0.049 0.3" type="capsule" />
             </body>
         </body>
     </worldbody>

--- a/playground/envs/cart_pole/cart_pole.xml
+++ b/playground/envs/cart_pole/cart_pole.xml
@@ -2,7 +2,7 @@
     <option solver="Newton" timestep="0.02" iterations="1" ls_iterations="4" />
     <compiler inertiafromgeom="true" />
     <default>
-        <joint armature="0" damping="1e-5" limited="true" />
+        <joint armature="0" damping="1e-2" limited="true" />
         <geom contype="0" />
     </default>
     <size nstack="3000" />

--- a/playground/envs/cart_pole/cart_pole_env.py
+++ b/playground/envs/cart_pole/cart_pole_env.py
@@ -99,7 +99,7 @@ class CartPoleSwingupEnv(PipelineEnv):
 
         # Compute the reward
         upright_reward = -jnp.square(theta_err).sum()
-        center_cart_reward = -jnp.square(pos).sum()
+        center_cart_reward = -jnp.square(jnp.square(pos)).sum()
         velocity_reward = -jnp.square(data.qvel).sum()
         control_reward = -jnp.square(data.ctrl).sum()
 

--- a/playground/envs/cart_pole/cart_pole_env.py
+++ b/playground/envs/cart_pole/cart_pole_env.py
@@ -24,7 +24,7 @@ class CartPoleSwingupConfig:
 
     # Reward function coefficients
     upright_angle_cost: float = 1.0
-    center_cart_cost: float = 0.1
+    center_cart_cost: float = 1.0
     velocity_cost: float = 0.01
     control_cost: float = 0.001
 
@@ -99,7 +99,7 @@ class CartPoleSwingupEnv(PipelineEnv):
 
         # Compute the reward
         upright_reward = -jnp.square(theta_err).sum()
-        center_cart_reward = -jnp.square(jnp.square(pos)).sum()
+        center_cart_reward = -jnp.square(pos).sum()
         velocity_reward = -jnp.square(data.qvel).sum()
         control_reward = -jnp.square(data.ctrl).sum()
 


### PR DESCRIPTION
Tune the cart-pole example to get a nicer swingup with ppo (doesn't rely on constraints). 

Includes changing the model to make the task easier (longer pendulum, less joint damping).